### PR TITLE
Change Camus example package name

### DIFF
--- a/camus-example/pom.xml
+++ b/camus-example/pom.xml
@@ -8,8 +8,8 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>camus-example</artifactId>
-  <name>Camus Examples</name>
+  <artifactId>confluent-camus</artifactId>
+  <name>Confluent Camus</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 			<dependency>
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-client</artifactId>
-				<version>1.0.3</version>
+				<version>2.5.0</version>
 			</dependency>
 			<dependency>
                 <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
Change camus example package name to confluent-camas. This closes https://github.com/confluentinc/camus/issues/2

@ewencp Can you take a quick look at this?
