### PR TITLE
Add recommendation for HDP version, and change version recommendataion to include greater versions since there is already a newer release of CDH.

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -184,7 +184,7 @@ Confluent version of Camus as follows:
 Requirements
 ------------
 
-- Hadoop: Camus works with both MRv1 and YARN. We recommend CDH 5.3.0
+- Hadoop: Camus works with both MRv1 and YARN. We recommend CDH >= 5.3.0 or HDP >= 2.2
 - Kafka: 0.8.2.0
 - Schema Registry: Confluent Schema Registry 1.0
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -184,7 +184,7 @@ Confluent version of Camus as follows:
 Requirements
 ------------
 
-- Hadoop: Camus works with both MRv1 and YARN. We recommend CDH >= 5.3.0 or HDP >= 2.2
+- Hadoop: Camus works with both MRv1 and YARN. We recommend CDH 5.3.x or HDP 2.2.x.
 - Kafka: 0.8.2.0
 - Schema Registry: Confluent Schema Registry 1.0
 


### PR DESCRIPTION
@Ishiihara @nehanarkhede Trivial fix, but wanted to check, does the >= make sense? There's already a newer CDH, so I figure we don't want to specify exact releases. Another alternative would be to specify versions like CDH 5.3.x and HDP 2.2.x.
