### PR TITLE
CachedSchemaRegistry to get the latest schema from its cache, too

### DIFF
--- a/camus-api/src/main/java/com/linkedin/camus/schemaregistry/CachedSchemaRegistry.java
+++ b/camus-api/src/main/java/com/linkedin/camus/schemaregistry/CachedSchemaRegistry.java
@@ -6,14 +6,14 @@ import java.util.concurrent.ConcurrentHashMap;
 public class CachedSchemaRegistry<S> implements SchemaRegistry<S> {
 	private final SchemaRegistry<S> registry;
 	private final ConcurrentHashMap<CachedSchemaTuple, S> cachedById;
-	private final ConcurrentHashMap<String, S> cachedLatest;
+	private final ConcurrentHashMap<String, SchemaDetails<S>> cachedLatest;
 	
 	public void init(Properties props) {}
 
 	public CachedSchemaRegistry(SchemaRegistry<S> registry) {
 		this.registry = registry;
 		this.cachedById = new ConcurrentHashMap<CachedSchemaTuple, S>();
-		this.cachedLatest = new ConcurrentHashMap<String, S>();
+		this.cachedLatest = new ConcurrentHashMap<String, SchemaDetails<S>>();
 	}
 
 	public String register(String topic, S schema) {
@@ -31,12 +31,12 @@ public class CachedSchemaRegistry<S> implements SchemaRegistry<S> {
 	}
 
 	public SchemaDetails<S> getLatestSchemaByTopic(String topicName) {
-		S schema = cachedLatest.get(topicName);
+		SchemaDetails<S> schema = cachedLatest.get(topicName);
 		if (schema == null) {
-			schema = registry.getLatestSchemaByTopic(topicName).getSchema();
+			schema = registry.getLatestSchemaByTopic(topicName);
 			cachedLatest.putIfAbsent(topicName, schema);
 		}
-		return registry.getLatestSchemaByTopic(topicName);
+		return schema;
 	}
 
 	public static class CachedSchemaTuple {


### PR DESCRIPTION
When not using the `MAGIC_BYTE` in the messages, the `CachedSchemaRegistry.java` is not using its cache to return the latest schema, it is _requesting the schema for every message_ instead. This will result in expensive operations and a lot of unnecessary load on the schema registry for high-volume Kafka topics. It should ensure it reads from its cache, just like for other schema's requests.

Note: This PR is the same as https://github.com/linkedin/camus/pull/169
