### PR TITLE
AvroMessageDecoder was expecting a byte[] whereas the Message interfa…

### DIFF
--- a/camus-kafka-coders/src/main/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoder.java
@@ -16,6 +16,7 @@
 package io.confluent.camus.etl.kafka.coders;
 
 import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.coders.Message;
 import com.linkedin.camus.coders.MessageDecoder;
 import com.linkedin.camus.coders.MessageDecoderException;
 
@@ -38,7 +39,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
-public class AvroMessageDecoder extends MessageDecoder<byte[], Record> {
+public class AvroMessageDecoder extends MessageDecoder<Message, Record> {
   private static final byte MAGIC_BYTE = 0x0;
   private static final int idSize = 4;
   private static final String SCHEMA_REGISTRY_URL = "schema.registry.url";
@@ -100,12 +101,12 @@ public class AvroMessageDecoder extends MessageDecoder<byte[], Record> {
     }
   }
 
-  private Object deserialize(byte[] payload) throws MessageDecoderException {
+  private Object deserialize(Message message) throws MessageDecoderException {
     try {
-      if (payload == null) {
+      if (message == null || message.getPayload() == null) {
         return null;
       }
-      ByteBuffer buffer = getByteBuffer(payload);
+      ByteBuffer buffer = getByteBuffer(message.getPayload());
       int id = buffer.getInt();
       Schema schema = schemaRegistry.getByID(id);
       if (schema == null)
@@ -152,8 +153,8 @@ public class AvroMessageDecoder extends MessageDecoder<byte[], Record> {
     }
   }
 
-  public CamusWrapper<Record> decode(byte[] payload) {
-    Object object = deserialize(payload);
+  public CamusWrapper<Record> decode(Message message) {
+    Object object = deserialize(message);
     if (object instanceof Record) {
       return new CamusAvroWrapper((Record) object);
     } else {


### PR DESCRIPTION
…ce should be used.

This fixes the exception raised with the current master:

```
[CamusJob] - Error for EtlKey [topic=XXXXXX partition=0leaderId= server= service= beginOffset=27 offset=28 msgSize=612 server= checksu
n: java.lang.ClassCastException: com.linkedin.camus.etl.kafka.common.KafkaMessage cannot be cast to [B
        at com.linkedin.camus.etl.kafka.mapred.EtlRecordReader.getWrappedRecord(EtlRecordReader.java:152)
        at com.linkedin.camus.etl.kafka.mapred.EtlRecordReader.nextKeyValue(EtlRecordReader.java:292)
        at org.apache.hadoop.mapred.MapTask$NewTrackingRecordReader.nextKeyValue(MapTask.java:556)
        at org.apache.hadoop.mapreduce.task.MapContextImpl.nextKeyValue(MapContextImpl.java:80)
        at org.apache.hadoop.mapreduce.lib.map.WrappedMapper$Context.nextKeyValue(WrappedMapper.java:91)
        at org.apache.hadoop.mapreduce.Mapper.run(Mapper.java:144)
        at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:787)
        at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
        at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:163)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:415)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1671)
        at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
Caused by: java.lang.ClassCastException: com.linkedin.camus.etl.kafka.common.KafkaMessage cannot be cast to [B
        at io.confluent.camus.etl.kafka.coders.AvroMessageDecoder.decode(AvroMessageDecoder.java:41)
        at com.linkedin.camus.etl.kafka.mapred.EtlRecordReader.getWrappedRecord(EtlRecordReader.java:142)
        ... 12 more
```
