### PR TITLE
Use Kafka 0.9.0.0-SNAPSHOT

### DIFF
--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.10</artifactId>
-            <version>0.8.2.0-cp</version>
+            <version>0.9.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.sgroschupf</groupId>

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTestWithMock.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTestWithMock.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
+import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -171,8 +172,8 @@ public class CamusJobTestWithMock {
     PartitionMetadata pMeta = EasyMock.createMock(PartitionMetadata.class);
     mocks.add(pMeta);
     EasyMock.expect(pMeta.errorCode()).andReturn((short)0).anyTimes();
-    Broker broker = new Broker(0, "localhost", 2121);
-    EasyMock.expect(pMeta.leader()).andReturn(broker).anyTimes();
+    Broker broker = new Broker(0, "localhost", 2121, SecurityProtocol.PLAINTEXT);
+    EasyMock.expect(pMeta.leader()).andReturn(broker.getBrokerEndPoint(SecurityProtocol.PLAINTEXT)).anyTimes();
     EasyMock.expect(pMeta.partitionId()).andReturn(PARTITION_1_ID).anyTimes();
     List<PartitionMetadata> partitionMetadatas = new ArrayList<PartitionMetadata>();
     partitionMetadatas.add(pMeta);    

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/KafkaCluster.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/KafkaCluster.java
@@ -12,7 +12,8 @@ import java.util.Random;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
 import kafka.utils.Time;
-import kafka.utils.Utils;
+import kafka.utils.CoreUtils;
+import scala.Option;
 
 import org.apache.zookeeper.server.NIOServerCnxn;
 import org.apache.zookeeper.server.ZooKeeperServer;
@@ -88,7 +89,8 @@ public class KafkaCluster {
   }
 
   private static KafkaServer startBroker(Properties props) {
-    KafkaServer server = new KafkaServer(new KafkaConfig(props), new SystemTime());
+    Option<String> noThreadNamePrefix = Option.empty();
+    KafkaServer server = new KafkaServer(new KafkaConfig(props), new SystemTime(), noThreadNamePrefix);
     server.startup();
     return server;
   }
@@ -145,8 +147,8 @@ public class KafkaCluster {
      */
     public void shutdown() {
       factory.shutdown();
-      Utils.rm(snapshotDir);
-      Utils.rm(logDir);
+      CoreUtils.rm(snapshotDir);
+      CoreUtils.rm(logDir);
     }
 
     public String getConnection() {

--- a/camus-kafka-coders/pom.xml
+++ b/camus-kafka-coders/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.10</artifactId>
-            <version>0.8.2.0-cp</version>
+            <version>0.9.0.0-SNAPSHOT</version>
         </dependency>
         <!-- Gson is needed for JSONStringMessageDecoder -->
         <dependency>

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -186,7 +186,7 @@ Requirements
 
 - Hadoop: Camus works with both MRv1 and YARN. We recommend CDH 5.3.x or HDP 2.2.x.
 - Kafka: 0.9.0.0
-- Schema Registry: Confluent Schema Registry 1.0
+- Schema Registry: Confluent Schema Registry 2.0.0
 
 Contribute
 ----------

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -185,7 +185,7 @@ Requirements
 ------------
 
 - Hadoop: Camus works with both MRv1 and YARN. We recommend CDH 5.3.x or HDP 2.2.x.
-- Kafka: 0.8.2.0
+- Kafka: 0.9.0.0
 - Schema Registry: Confluent Schema Registry 1.0
 
 Contribute

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.10</artifactId>
-                <version>0.8.2.0-cp</version>
+                <version>0.9.0.0-SNAPSHOT</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR updates Camus from Kafka 0.8.2.0-cp to Kafka 0.9.0.0-SNAPSHOT.

Because of Kafka API changes (e.g. newly added SSL support) this required a few changes, which are not available in the upstream Camus project (and most likely will never be as LinkedIn is deprecating Camus in favor of Goblin).
