### PR TITLE
Incorrect schema subject name when decoding Avro

### DIFF
--- a/camus-kafka-coders/src/main/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoder.java
@@ -95,9 +95,9 @@ public class AvroMessageDecoder extends MessageDecoder<Message, Record> {
 
   private String constructSubject(String topic, Schema schema, boolean isNewProducer) {
     if (isNewProducer) {
-      return topic + "-value";
-    } else {
       return schema.getName() + "-value";
+    } else {
+      return topic + "-value";
     }
   }
 

--- a/camus-kafka-coders/src/test/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoderTest.java
+++ b/camus-kafka-coders/src/test/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoderTest.java
@@ -149,8 +149,8 @@ public class AvroMessageDecoderTest {
 
     IndexedRecord avroRecordV1 = createAvroRecordVersion1();
     byte[] payloadV1 = avroSerializer.serialize(avroRecordV1.getSchema().getName(), avroRecordV1);
-    Object avroRecordV2 = createAvroRecordVersion2();
-    byte[] payloadV2 = avroSerializer.serialize(topic, avroRecordV2);
+    IndexedRecord avroRecordV2 = createAvroRecordVersion2();
+    byte[] payloadV2 = avroSerializer.serialize(avroRecordV2.getSchema().getName(), avroRecordV2);
 
     AvroMessageDecoder decoder = createAvroDecoder(topic, true, schemaRegistry);
     try {
@@ -168,12 +168,12 @@ public class AvroMessageDecoderTest {
     String topic = "testAvro";
 
     IndexedRecord avroRecordV1 = createAvroRecordVersion1();
-    byte[] payloadV1 = avroSerializer.serialize(topic, avroRecordV1);
+    byte[] payloadV1 = avroSerializer.serialize(avroRecordV1.getSchema().getName(), avroRecordV1);
     AvroMessageDecoder decoder = createAvroDecoder(topic, true, schemaRegistry);
 
     decoder.decode(new TestMessage(payloadV1));
-    Object avroRecordV2 = createAvroRecordVersion2();
-    byte[] payloadV2 = avroSerializer.serialize(topic, avroRecordV2);
+    IndexedRecord avroRecordV2 = createAvroRecordVersion2();
+    byte[] payloadV2 = avroSerializer.serialize(avroRecordV2.getSchema().getName(), avroRecordV2);
     try {
       decoder.decode(new TestMessage(payloadV2));
       fail("AvroMessageDecoder should not be able to decode Avro record with new schema version");

--- a/camus-kafka-coders/src/test/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoderTest.java
+++ b/camus-kafka-coders/src/test/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoderTest.java
@@ -130,14 +130,14 @@ public class AvroMessageDecoderTest {
   public void testAvroDecoder() {
     String topic = "testAvro";
 
-    Object avroRecord = createAvroRecordVersion1();
-    byte[] payload = avroSerializer.serialize(topic, avroRecord);
+    IndexedRecord avroRecord = createAvroRecordVersion1();
+    byte[] payload = avroSerializer.serialize(avroRecord.getSchema().getName(), avroRecord);
     AvroMessageDecoder decoder = createAvroDecoder(topic, true, schemaRegistry);
 
     Object record = decoder.decode(new TestMessage(payload)).getRecord();
     assertEquals(avroRecord, record);
 
-    payload= avroEncoder.toBytes(avroRecord);
+    byte[] payload2 = avroSerializer.serialize(topic, avroRecord);
     AvroMessageDecoder decoder2 = createAvroDecoder(topic, false, schemaRegistry);
     record = decoder2.decode(new TestMessage(payload)).getRecord();
     assertEquals(avroRecord, record);
@@ -147,8 +147,8 @@ public class AvroMessageDecoderTest {
   public void testAvroDecoderCompatible() {
     String topic = "testAvro";
 
-    Object avroRecordV1 = createAvroRecordVersion1();
-    byte[] payloadV1 = avroSerializer.serialize(topic, avroRecordV1);
+    IndexedRecord avroRecordV1 = createAvroRecordVersion1();
+    byte[] payloadV1 = avroSerializer.serialize(avroRecordV1.getSchema().getName(), avroRecordV1);
     Object avroRecordV2 = createAvroRecordVersion2();
     byte[] payloadV2 = avroSerializer.serialize(topic, avroRecordV2);
 
@@ -167,7 +167,7 @@ public class AvroMessageDecoderTest {
   public void testAvroDecoderFailure() {
     String topic = "testAvro";
 
-    Object avroRecordV1 = createAvroRecordVersion1();
+    IndexedRecord avroRecordV1 = createAvroRecordVersion1();
     byte[] payloadV1 = avroSerializer.serialize(topic, avroRecordV1);
     AvroMessageDecoder decoder = createAvroDecoder(topic, true, schemaRegistry);
 


### PR DESCRIPTION
AvroMessageDecoder is using the topic name for the subject when the "is.new.producer" setting is true.  It's supposed to be the other way around.
