### PR TITLE
Added guard for expensive debug logging

### DIFF
--- a/camus-kafka-coders/src/main/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoder.java
@@ -111,7 +111,9 @@ public class AvroMessageDecoder extends MessageDecoder<Message, Record> {
       Schema schema = schemaRegistry.getByID(id);
       if (schema == null)
         throw new IllegalStateException("Unknown schema id: " + id);
-      logger.debug("Schema = " + schema.toString());
+      if (logger.isDebugEnabled()) {
+        logger.debug("Schema = " + schema.toString());
+      }
       String subject = constructSubject(topic, schema, isNew);
       logger.debug("Subject = " + subject);
 


### PR DESCRIPTION
In my testing, adding a guard for this logging statement improved performance by about 40%.
