### PR TITLE
Execute debug specific code only when debug logging is enabled

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlCounts.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlCounts.java
@@ -237,7 +237,11 @@ public class EtlCounts {
     props.put("producer.type", "async");
     props.put("request.required.acks", "1");
     props.put("request.timeout.ms", "30000");
-    log.debug("Broker list: " + brokerList);
+
+    if (log.isDebugEnabled()) {
+      log.debug("Broker list: " + brokerList);
+    }
+
     Producer producer = new Producer(new ProducerConfig(props));
     try {
       for (byte[] message : monitorSet) {

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
@@ -146,7 +146,11 @@ public class KafkaReader {
     }
     long tempTime = System.currentTimeMillis();
     TopicAndPartition topicAndPartition = new TopicAndPartition(kafkaRequest.getTopic(), kafkaRequest.getPartition());
-    log.debug("\nAsking for offset : " + (currentOffset));
+
+    if (log.isDebugEnabled()) {
+      log.debug("\nAsking for offset : " + (currentOffset));
+    }
+
     PartitionFetchInfo partitionFetchInfo = new PartitionFetchInfo(currentOffset, fetchBufferSize);
 
     HashMap<TopicAndPartition, PartitionFetchInfo> fetchInfo = new HashMap<TopicAndPartition, PartitionFetchInfo>();
@@ -168,8 +172,12 @@ public class KafkaReader {
         ByteBufferMessageSet messageBuffer =
             fetchResponse.messageSet(kafkaRequest.getTopic(), kafkaRequest.getPartition());
         lastFetchTime = (System.currentTimeMillis() - tempTime);
-        log.debug("Time taken to fetch : " + (lastFetchTime / 1000) + " seconds");
-        log.debug("The size of the ByteBufferMessageSet returned is : " + messageBuffer.sizeInBytes());
+
+        if (log.isDebugEnabled()) {
+          log.debug("Time taken to fetch : " + (lastFetchTime / 1000) + " seconds");
+          log.debug("The size of the ByteBufferMessageSet returned is : " + messageBuffer.sizeInBytes());
+        }
+
         int skipped = 0;
         totalFetchTime += lastFetchTime;
         messageIter = messageBuffer.iterator();
@@ -182,14 +190,25 @@ public class KafkaReader {
             //flag = true;
             skipped++;
           } else {
-            log.debug("Skipped offsets till : " + message.offset());
+            if (log.isDebugEnabled()) {
+              log.debug("Skipped offsets till : " + message.offset());
+            }
+
             break;
           }
         }
-        log.debug("Number of offsets to be skipped: " + skipped);
+
+        if (log.isDebugEnabled()) {
+          log.debug("Number of offsets to be skipped: " + skipped);
+        }
+
         while (skipped != 0) {
           MessageAndOffset skippedMessage = messageIter.next();
-          log.debug("Skipping offset : " + skippedMessage.offset());
+
+          if (log.isDebugEnabled()) {
+            log.debug("Skipping offset : " + skippedMessage.offset());
+          }
+
           skipped--;
         }
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitter.java
@@ -129,7 +129,11 @@ public class EtlMultiOutputCommitter extends FileOutputCommitter {
         log.info("Writing counts to : " + tempPath.toString());
         long time = System.currentTimeMillis();
         mapper.writeValue(outputStream, allCountObject);
-        log.debug("Time taken : " + (System.currentTimeMillis() - time) / 1000);
+
+        if (log.isDebugEnabled()) {
+          log.debug("Time taken : " + (System.currentTimeMillis() - time) / 1000);
+        }
+
       }
     } else {
       log.info("Not moving run data.");

--- a/camus-kafka-coders/src/main/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoder.java
@@ -85,7 +85,11 @@ public class AvroMessageDecoder extends MessageDecoder<byte[], Record> {
   private ByteBuffer getByteBuffer(byte[] payload) {
     ByteBuffer buffer = ByteBuffer.wrap(payload);
     byte magic = buffer.get();
-    logger.debug("MAGIC BYTE" + magic);
+
+    if (logger.isDebugEnabled()) {
+      logger.debug("MAGIC BYTE" + magic);
+    }
+
     if (magic != MAGIC_BYTE) {
       throw new MessageDecoderException("Unknown magic byte!");
     }
@@ -108,11 +112,16 @@ public class AvroMessageDecoder extends MessageDecoder<byte[], Record> {
       ByteBuffer buffer = getByteBuffer(payload);
       int id = buffer.getInt();
       Schema schema = schemaRegistry.getByID(id);
-      if (schema == null)
+      if (schema == null) {
         throw new IllegalStateException("Unknown schema id: " + id);
-      logger.debug("Schema = " + schema.toString());
+      }
+
       String subject = constructSubject(topic, schema, isNew);
-      logger.debug("Subject = " + subject);
+
+      if (logger.isDebugEnabled()) {
+        logger.debug("Schema = " + schema.toString());
+        logger.debug("Subject = " + subject);
+      }
 
       // We need to initialize latestSchema and latestVersion here
       // to handle both old and new producers as we don't know

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusCleaner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusCleaner.java
@@ -95,7 +95,10 @@ public class CamusCleaner extends Configured implements Tool {
 
     sourcePath = fs.getFileStatus(new Path(fromLocation)).getPath();
 
-    log.debug("Path : " + sourcePath);
+    if (log.isDebugEnabled()) {
+      log.debug("Path : " + sourcePath);
+    }
+
     simulate = Boolean.parseBoolean(props.getProperty(SIMULATE, "false"));
     force = Boolean.parseBoolean(props.getProperty(FORCE, "false"));
 

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperPlanner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperPlanner.java
@@ -29,8 +29,10 @@ public abstract class CamusSweeperPlanner {
   // folder
   protected boolean shouldReprocess(FileSystem fs, List<Path> sources, Path dest) throws IOException {
 
-    log.debug("source:" + sources.toString());
-    log.debug("dest:" + dest.toString());
+    if (log.isDebugEnabled()) {
+      log.debug("source:" + sources.toString());
+      log.debug("dest:" + dest.toString());
+    }
 
     FileStatus destStatus = fs.getFileStatus(dest);
     long destinationModTime = destStatus.getModificationTime();
@@ -46,8 +48,10 @@ public abstract class CamusSweeperPlanner {
   private boolean shouldReprocess(FileSystem fs, Path source, long destinationModTime) throws IOException {
     FileStatus sourceStatus = fs.getFileStatus(source);
 
-    log.debug("source mod:" + sourceStatus.getModificationTime());
-    log.debug("dest mod:" + destinationModTime);
+    if (log.isDebugEnabled())  {
+      log.debug("source mod:" + sourceStatus.getModificationTime());
+      log.debug("dest mod:" + destinationModTime);
+    }
 
     if (sourceStatus.getModificationTime() > destinationModTime) {
       return true;


### PR DESCRIPTION
Current 1.0.1 release has a major performance defect caused by excessive debug logging in [camus-kafka-coders/src/main/java/io/confluent/camus/etl/kafka/coders/AvroMessageDecoder.java#L113]:

```
logger.debug("Schema = " + schema.toString());
```

Schema is serialized each time new message arrives. However, as debug logging is disabled it is never printed to log.

Applied fix showed up to 10x performance improvement.

PR is submitted to 1.x-0.9.0.0 branch as it seem to be the most active for 1.x version.
