### PR TITLE
CC-1350: Temporarily corrected AK core’s missing dependency on SLF4J API

### DIFF
--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -24,6 +24,12 @@
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 		</dependency>
+		<!-- Workaround for KAFKA-6313: Use the Kafka clients to bring in the SLF4J API dependency now. -->
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>${kafka.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro-mapred</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,12 @@
 			<dependency>
 				<groupId>com.101tec</groupId>
 				<artifactId>zkclient</artifactId>
-				<version>0.8</version>
+				<version>0.10</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.zookeeper</groupId>
 				<artifactId>zookeeper</artifactId>
-				<version>3.4.6</version>
+				<version>3.4.10</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>


### PR DESCRIPTION
Recent changes in the 1.1.0-SNAPSHOT version of AK added code that depends on the SLF4J API library, but AK is not currently including that in the `org.apache:kafka_2.11` dependencies (see [KAFKA-6313](https://issues.apache.org/jira/browse/KAFKA-6313)).

This commit *temporarily* adds them via the `org.apache:kafka-clients` library, which does depend on the correct version of SLF4J API. This corrects the problem, but we’ll want to revert this when KAFKA-6313 is fixed.