### PR TITLE
Pin Kafka version to 1.1.0 and CP version to 4.1.1

### DIFF
--- a/camus-kafka-coders/pom.xml
+++ b/camus-kafka-coders/pom.xml
@@ -15,12 +15,12 @@
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-schema-registry-client</artifactId>
-			<version>${project.version}</version>
+			<version>${confluent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-avro-serializer</artifactId>
-			<version>${project.version}</version>
+			<version>${confluent.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
 		<kafka.scala.version>2.11</kafka.scala.version>
-		<kafka.version>2.0.0-SNAPSHOT</kafka.version>
+		<kafka.version>1.1.0</kafka.version>
 		<avro.version>1.8.2</avro.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+                <confluent.version>4.1.1</confluent.version>
 		<kafka.scala.version>2.11</kafka.scala.version>
 		<kafka.version>1.1.0</kafka.version>
 		<avro.version>1.8.2</avro.version>


### PR DESCRIPTION
The Scala producer has been removed from
Kafka 2.0.0 and the Avro/Json encoders
for the old producer have been removed in
CP 5.0.0.