### PR TITLE
CC-2264: Pin maven-site-plugin to a specific version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,15 @@
 	</repositories>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-site-plugin</artifactId>
+					<version>3.7.1</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
We implicitly determine the version of the `maven-site-plugin`, but recently an incompatible 3.x version was published and is causing this build to fail. Pinning this to 3.7.1 across multiple branches.
