### PR TITLE
MINOR: Remove Jenkinsfile from master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,0 @@
-#!/usr/bin/env groovy
-common {
-  slackChannel = '#connect-eng'
-  upstreamProjects = 'confluentinc/schema-registry'
-}


### PR DESCRIPTION
We don’t want to build `master` branch, so removing the Jenkinsfile will stop those builds.

Do not merge on any other branches.