### PR TITLE
Strip out -cpN suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test:
 
 
 
-export RPM_VERSION=$(shell echo $(VERSION) | sed -e 's/-alpha[0-9]*//' -e 's/-beta[0-9]*//' -e 's/-rc[0-9]*//' -e 's/-SNAPSHOT//')
+export RPM_VERSION=$(shell echo $(VERSION) | sed -e 's/-alpha[0-9]*//' -e 's/-beta[0-9]*//' -e 's/-rc[0-9]*//' -e 's/-SNAPSHOT//' -e 's/-cp[0-9]*//')
 # Get any -alpha, -beta, -rc piece that we need to put into the Release part of
 # the version since RPM versions don't support non-numeric
 # characters. Ultimately, for something like 0.8.2-beta, we want to end up with


### PR DESCRIPTION
This will allow us to release hotfix versions of released CP